### PR TITLE
Add start time input

### DIFF
--- a/lib/components/BuilderForm.jsx
+++ b/lib/components/BuilderForm.jsx
@@ -58,7 +58,8 @@ export const BuilderForm = (props) => {
     ticketSymbol,
     creditMaturationInDays,
     ticketCreditLimitPercentage,
-    numberOfWinners
+    numberOfWinners,
+    prizePeriodStartAt
   } = vars
 
   const {
@@ -76,7 +77,8 @@ export const BuilderForm = (props) => {
     setTicketSymbol,
     setCreditMaturationInDays,
     setTicketCreditLimitPercentage,
-    setNumberOfWinners
+    setNumberOfWinners,
+    setPrizePeriodStartAt
   } = stateSetters
 
   const [userChangedCreditMaturation, setUserChangedCreditMaturation] = useState(false)
@@ -189,6 +191,8 @@ export const BuilderForm = (props) => {
               setCreditMaturationInDays={setCreditMaturationInDays}
               setPrizePeriodInDays={setPrizePeriodInDays}
               prizePeriodInDays={prizePeriodInDays}
+              prizePeriodStartAt={prizePeriodStartAt}
+              setPrizePeriodStartAt={setPrizePeriodStartAt}
             />
 
             <NumberOfWinnersCard

--- a/lib/components/BuilderUI.jsx
+++ b/lib/components/BuilderUI.jsx
@@ -64,7 +64,7 @@ const sendPrizeStrategyTx = async (
     ? ethers.utils.parseEther(ticketCreditLimitMantissa).div(ticketCreditMaturationInSeconds)
     : ethers.BigNumber.from(0)
 
-  const prizePeriodStartInt = parseInt(prizePeriodStartAt, 10)
+  const prizePeriodStartInt = prizePeriodStartAt ? parseInt(prizePeriodStartAt, 10) : 0
   const prizePeriodStartTimestamp = (prizePeriodStartInt === 0
     ? now()
     : prizePeriodStartInt
@@ -269,7 +269,7 @@ export const BuilderUI = (props) => {
   const [yieldSourceData, setYieldSourceData] = useState()
 
   const [rngService, setRngService] = useState('')
-  const [prizePeriodStartAt, setPrizePeriodStartAt] = useState('0')
+  const [prizePeriodStartAt, setPrizePeriodStartAt] = useState('')
   const [prizePeriodInDays, setPrizePeriodInDays] = useState('7')
   const [sponsorshipName, setSponsorshipName] = useState('PT Sponsorship')
   const [sponsorshipSymbol, setSponsorshipSymbol] = useState('S')

--- a/lib/components/PrizePeriodCard.jsx
+++ b/lib/components/PrizePeriodCard.jsx
@@ -76,10 +76,18 @@ export const PrizePeriodCard = (props) => {
               value={prizePeriodStartAt}
               unit='seconds'
             />
-            <div className='w-full sm:w-1/2 sm:ml-4 text-accent-1 flex flex-col my-auto'>
-              <span className='mb-4'>Current unix time: {secondsSinceEpoch}</span>
+            <div className='w-full sm:w-1/2 sm:ml-4 text-accent-1 flex flex-col '>
+              <span className='mb-1'>
+                <span className='font-bold'>Current unix time:</span>{' '}
+                <span>{secondsSinceEpoch}</span>
+              </span>
               {date && (
-                <span>{`Input date: ${date?.toDateString()} ${date?.toLocaleTimeString()}`}</span>
+                <span>
+                  <span className='font-bold'>Input date:</span>{' '}
+                  <span>
+                    {date?.toDateString()}, {date?.toLocaleTimeString()}
+                  </span>
+                </span>
               )}
             </div>
           </div>

--- a/lib/components/PrizePeriodCard.jsx
+++ b/lib/components/PrizePeriodCard.jsx
@@ -1,17 +1,31 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import { Card } from 'lib/components/Card'
 import { InputLabel } from 'lib/components/InputLabel'
 import { TextInputGroup, TextInputGroupType } from 'lib/components/TextInputGroup'
 import { DAYS_STEP, FEE_DECAY_DURATION_COEFFICIENT } from 'lib/constants'
+import { Collapse } from 'lib/components/Collapse'
+import { useInterval } from 'lib/hooks/useInterval'
 
 export const PrizePeriodCard = (props) => {
   const {
     userChangedCreditMaturation,
     setCreditMaturationInDays,
     setPrizePeriodInDays,
-    prizePeriodInDays
+    prizePeriodInDays,
+    prizePeriodStartAt,
+    setPrizePeriodStartAt
   } = props
+
+  const [secondsSinceEpoch, setSecondsSinceEpoch] = useState(
+    Math.floor(new Date().getTime() / 1000)
+  )
+  useInterval(() => setSecondsSinceEpoch(secondsSinceEpoch + 1))
+
+  const date =
+    prizePeriodStartAt && Number(prizePeriodStartAt)
+      ? new Date(Number(prizePeriodStartAt) * 1000)
+      : null
 
   return (
     <Card>
@@ -41,6 +55,36 @@ export const PrizePeriodCard = (props) => {
           unit='days'
         />
       </InputLabel>
+
+      <Collapse title='Advanced Settings' className='mt-4 sm:mt-8'>
+        <InputLabel
+          secondary='Prize Pool Start Time'
+          description={`Provide the unix time stamp of the start time of the first prize period (in seconds). If no number is provided, the first prize period will begin as soon as the prize pool is created.`}
+        >
+          <div className='flex flex-col sm:flex-row'>
+            <TextInputGroup
+              id='_startTime'
+              containerClassName='w-full sm:w-1/2 sm:mr-4'
+              type={TextInputGroupType.number}
+              step={1}
+              min={secondsSinceEpoch}
+              label='Start Time'
+              placeholder='1618609964'
+              onChange={(e) => {
+                setPrizePeriodStartAt(e.target.value)
+              }}
+              value={prizePeriodStartAt}
+              unit='seconds'
+            />
+            <div className='w-full sm:w-1/2 sm:ml-4 text-accent-1 flex flex-col my-auto'>
+              <span className='mb-4'>Current unix time: {secondsSinceEpoch}</span>
+              {date && (
+                <span>{`Input date: ${date?.toDateString()} ${date?.toLocaleTimeString()}`}</span>
+              )}
+            </div>
+          </div>
+        </InputLabel>
+      </Collapse>
     </Card>
   )
 }

--- a/lib/hooks/useInterval.js
+++ b/lib/hooks/useInterval.js
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from 'react'
+
+export const useInterval = (callback, delay = 1000) => {
+  const savedCallback = useRef()
+
+  useEffect(() => {
+    savedCallback.current = callback
+  })
+
+  useEffect(() => {
+    function tick() {
+      savedCallback.current()
+    }
+
+    if (delay !== null) {
+      let id = setInterval(tick, delay)
+      return () => clearInterval(id)
+    }
+  }, [delay])
+}


### PR DESCRIPTION
<img width="821" alt="Screen Shot 2021-04-16 at 6 14 07 PM" src="https://user-images.githubusercontent.com/13701258/115089105-98008a80-9edf-11eb-86e3-a100285e0b4f.png">

Test pool with a wild start time - https://rinkeby.etherscan.io/address/0xd751cCa8611Ee6e504f906A071F58312A150cC6a#readContract